### PR TITLE
More postinstall-script functionality.

### DIFF
--- a/host/templates/ajax/hostForm.html
+++ b/host/templates/ajax/hostForm.html
@@ -32,6 +32,18 @@
   </div>
 
   <div class="form-group">
+    <label class="control-label col-sm-2" for="postinstall">Postinstall-script</label>
+    <div class="col-sm-10">
+      <select class="form-control" id="postinstall">
+        <option value="0">None</option>
+        {% for bf in bootfiles %}
+          <option value="{{bf.id}}">{{bf.name}}</option>
+        {% endfor %}
+      </select>
+    </div>
+  </div>
+
+  <div class="form-group">
     <label class="control-label col-sm-2" for="environment">Environment</label>
     <div class="col-sm-10">
       <select class="form-control" id="environment">
@@ -53,7 +65,7 @@
   <div class="form-group">
     <label class="control-label col-sm-2" for="ifname">Interface name</label>
     <div class="col-sm-10">
-      <input type="text" class="form-control" id="ifname" placeholder="eth0">
+      <input type="text" class="form-control" id="ifname" placeholder="auto">
     </div>
   </div>
 

--- a/host/templates/hostOverview.html
+++ b/host/templates/hostOverview.html
@@ -355,6 +355,7 @@
             'csrfmiddlewaretoken' : $('input[name=csrfmiddlewaretoken]').val(),
             'hostname'            : $('input[id=hostname]').val(),
             'os'                  : $('#os option:selected').index(),
+            'postinstall'         : $('#postinstall option:selected').val(),
             'bootfile'            : $('#bootfile option:selected').val(),
             'environment'         : $('#environment option:selected').text(), 
             'role'                : $('#role option:selected').text(), 

--- a/host/templates/hostStatus.html
+++ b/host/templates/hostStatus.html
@@ -33,12 +33,6 @@
         <td><a href="{% url 'hostTftp' host.id %}">TFTP config</a></td>
       </tr>
       <tr>
-        <td class="rightText">Postinstall-script:</td>
-        <td>
-          <a href="{% url 'hostPostinstall' host.id %}">Postinstall-script</a>
-        </td>
-      </tr>
-      <tr>
         <td class="rightText">Status:</td>
         <td>{{host.getStatusText}}</td>
       </tr>

--- a/host/templates/tftpboot/install.cfg
+++ b/host/templates/tftpboot/install.cfg
@@ -1,4 +1,4 @@
 DEFAULT install
 LABEL install
 	KERNEL {{host.os.shortname}}/{{host.os.kernelname}}
-	APPEND auto initrd={{host.os.shortname}}/{{host.os.initrdname}} url=http://{{dashboardURL}}/host/{{host.id}}/preseed locale=en_US keyboard-configuration/layoutcode=us hostname={{host.name}} interface=auto -- quiet 
+	APPEND auto initrd={{host.os.shortname}}/{{host.os.initrdname}} url=http://{{dashboardURL}}/host/{{host.id}}/preseed locale=en_US keyboard-configuration/layoutcode=no hostname={{host.name}} interface={{host.getPrimaryIf.ifname}} -- quiet 

--- a/host/views/ajax.py
+++ b/host/views/ajax.py
@@ -414,6 +414,15 @@ def new(request):
       response['status'] = "danger"
       response['message'] = "Bootfile not found."
 
+  if(request.POST['postinstall'] == '0'):
+    postinstall = None
+  else:
+    try:
+      postinstall = BootFile.objects.get(pk=int(request.POST['postinstall']))
+    except PartitionScheme.DoesNotExist:
+      response['status'] = "danger"
+      response['message'] = "Postinstallscript not found."
+
   if(int(request.POST['os'])):
     try:
       os = OperatingSystem.objects.all()[int(request.POST['os'])-1]
@@ -527,7 +536,7 @@ def new(request):
   
   host = Host(name=request.POST['hostname'], 
       environment=environment, status = Host.PROVISIONING, role=role,
-      bootfile=bootfile, os=os)
+      bootfile=bootfile, postinstallscript=postinstall, os=os)
   host.save()
   network = subnet.v4network.get()
   interface = Interface(ifname=request.POST['ifname'], mac=mac, host=host,


### PR DESCRIPTION
 - Add possibility to set postinstall-script when creating a host. 
 - Removed a redundant link in the host overview. 
 - Grab interface-name from the primary interface when creating TFTP config. 
   - Mark: you must set the primary interface name to 'auto' to keep the old behaviour (where it always was auto).